### PR TITLE
Fixes creation of replicator user

### DIFF
--- a/scripts/postgresql_master_setup.sh
+++ b/scripts/postgresql_master_setup.sh
@@ -16,10 +16,6 @@ sudo -u root bash -c "firewall-cmd --permanent --zone=trusted --add-source=${pg_
 sudo -u root bash -c "firewall-cmd --permanent --zone=trusted --add-port=5432/tcp"
 sudo -u root bash -c "firewall-cmd --reload"
 
-# Create replication user
-chown postgres /tmp/postgresql_master_setup.sql
-sudo -u postgres bash -c "psql -d template1 -f /tmp/postgresql_master_setup.sql"
-
 # Update the content of postgresql.conf to support WAL
 sudo -u root bash -c "echo 'wal_level = replica' | sudo tee -a $DATA_DIR/postgresql.conf"
 sudo -u root bash -c "echo 'archive_mode = on' | sudo tee -a $DATA_DIR/postgresql.conf"
@@ -46,3 +42,7 @@ sudo -u root bash -c "chown postgres $DATA_DIR/pg_hba.conf"
 sudo systemctl stop postgresql
 sudo systemctl start postgresql
 sudo systemctl status postgresql
+
+# Create replication user
+chown postgres /tmp/postgresql_master_setup.sql
+sudo -u postgres bash -c "psql -d template1 -f /tmp/postgresql_master_setup.sql"

--- a/scripts/postgresql_standby_setup.sh
+++ b/scripts/postgresql_standby_setup.sh
@@ -19,7 +19,7 @@ Environment=PGLOG=/u01/data/pgstartup.log
 EOF
 
 # Change password of postgres user
-sudo -u root bash -c "echo postgres:345database5678password0238 | chpasswd"
+sudo -u root bash -c "echo postgres:${pg_replicat_password} | chpasswd"
 
 # Setting firewall rules
 sudo -u root bash -c "firewall-cmd --permanent --zone=trusted --add-source=${pg_master_ip}/32"


### PR DESCRIPTION
This PR moves the creation of the replication user as sometimes postgreSQL wouldn't start in time for the user to be successfully created. 

This fix should prevent any chance of this happening going forward.