### PR TITLE
Fixes script paths for updated versions of Terraform

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,8 +190,7 @@ postgresql_master_memory_in_gb  = "32"
 - Compute ssh keys to later log into instances. Paths to the keys should be provided in variables `ssh_public_key` and `ssh_private_key`.
 - Variable `compute_nsg_name` is an optional network security group that can be attached.
 - Variable `postgresql_replicat_username` is used as a login name to setup replication. This doesn't need to be supplied in a master only configuration.
-- Variable `postgresql_version` can be any of the supported version of PostgreSQL at the time of making this brick (`9.6`, `10`, `11`, `12`, `13` and `14`).
-*Note*: PostgreSQL version `9.6` will lose official support from `11 Nov 2021`.
+- Variable `postgresql_version` can be any of the supported version of PostgreSQL at the time of making this brick (`11`, `12`, `13` and `14`).
 - Variable `database_size_in_gb` is the size of the attached ISCSI disks to store the PostgreSQL database on. This can be between `50` and `32768`.
 - Variable `database_vpus_per_gb` is the number of volume performance units to be applied to the attached ISCSI disks. The value must be between `0` and `120` and be multiple of 10.
 - Variable `database_backup_policy_level` specifies the name of the backup policy used on the attached database ISCSI disks.

--- a/outputs.tf
+++ b/outputs.tf
@@ -6,7 +6,6 @@
 
 output "PostgreSQL_Master" {
   description = "PostgreSQL Master Instance"
-  sensitive   = true
   value       = oci_core_instance.postgresql_master
 }
 

--- a/postgresconfig.tf
+++ b/postgresconfig.tf
@@ -94,7 +94,7 @@ resource "null_resource" "postgresql_master_install_binaries" {
 
     }
     inline = [
-      "sudo rm -rf ~/postgresql_install_binaries.sh"
+      "sudo rm -rf /tmp/postgresql_install_binaries.sh"
     ]
   }
 
@@ -108,7 +108,7 @@ resource "null_resource" "postgresql_master_install_binaries" {
     }
 
     content     = data.template_file.postgresql_install_binaries_sh.rendered
-    destination = "~/postgresql_install_binaries.sh"
+    destination = "/tmp/postgresql_install_binaries.sh"
   }
 
   provisioner "remote-exec" {
@@ -120,8 +120,8 @@ resource "null_resource" "postgresql_master_install_binaries" {
 
     }
     inline = [
-      "chmod +x ~/postgresql_install_binaries.sh",
-      "sudo ~/postgresql_install_binaries.sh"
+      "chmod +x /tmp/postgresql_install_binaries.sh",
+      "sudo /tmp/postgresql_install_binaries.sh"
     ]
   }
 }
@@ -138,7 +138,7 @@ resource "null_resource" "postgresql_master_initdb" {
 
     }
     inline = [
-      "sudo rm -rf ~/postgresql_master_initdb.sh"
+      "sudo rm -rf /tmp/postgresql_master_initdb.sh"
     ]
   }
 
@@ -152,7 +152,7 @@ resource "null_resource" "postgresql_master_initdb" {
     }
 
     content     = data.template_file.postgresql_master_initdb_sh.rendered
-    destination = "~/postgresql_master_initdb.sh"
+    destination = "/tmp/postgresql_master_initdb.sh"
   }
 
   provisioner "remote-exec" {
@@ -164,8 +164,8 @@ resource "null_resource" "postgresql_master_initdb" {
 
     }
     inline = [
-      "chmod +x ~/postgresql_master_initdb.sh",
-      "sudo ~/postgresql_master_initdb.sh"
+      "chmod +x /tmp/postgresql_master_initdb.sh",
+      "sudo /tmp/postgresql_master_initdb.sh"
     ]
   }
 }
@@ -191,7 +191,7 @@ resource "null_resource" "postgresql_hotstandby1_install_binaries" {
 
     }
     inline = [
-      "sudo rm -rf ~/postgresql_install_binaries.sh"
+      "sudo rm -rf /tmp/postgresql_install_binaries.sh"
     ]
   }
 
@@ -205,7 +205,7 @@ resource "null_resource" "postgresql_hotstandby1_install_binaries" {
     }
 
     content     = data.template_file.postgresql_install_binaries_sh.rendered
-    destination = "~/postgresql_install_binaries.sh"
+    destination = "/tmp/postgresql_install_binaries.sh"
   }
 
   provisioner "remote-exec" {
@@ -217,8 +217,8 @@ resource "null_resource" "postgresql_hotstandby1_install_binaries" {
 
     }
     inline = [
-      "chmod +x ~/postgresql_install_binaries.sh",
-      "sudo ~/postgresql_install_binaries.sh"
+      "chmod +x /tmp/postgresql_install_binaries.sh",
+      "sudo /tmp/postgresql_install_binaries.sh"
     ]
   }
 }
@@ -244,7 +244,7 @@ resource "null_resource" "postgresql_hotstandby2_install_binaries" {
 
     }
     inline = [
-      "sudo rm -rf ~/postgresql_install_binaries.sh"
+      "sudo rm -rf /tmp/postgresql_install_binaries.sh"
     ]
   }
 
@@ -258,7 +258,7 @@ resource "null_resource" "postgresql_hotstandby2_install_binaries" {
     }
 
     content     = data.template_file.postgresql_install_binaries_sh.rendered
-    destination = "~/postgresql_install_binaries.sh"
+    destination = "/tmp/postgresql_install_binaries.sh"
   }
 
   provisioner "remote-exec" {
@@ -270,8 +270,8 @@ resource "null_resource" "postgresql_hotstandby2_install_binaries" {
 
     }
     inline = [
-      "chmod +x ~/postgresql_install_binaries.sh",
-      "sudo ~/postgresql_install_binaries.sh"
+      "chmod +x /tmp/postgresql_install_binaries.sh",
+      "sudo /tmp/postgresql_install_binaries.sh"
     ]
   }
 }
@@ -290,7 +290,7 @@ resource "null_resource" "postgresql_master_setup" {
 
     }
     inline = [
-      "sudo rm -rf ~/postgresql_master_setup.sh",
+      "sudo rm -rf /tmp/postgresql_master_setup.sh",
       "sudo rm -rf /tmp/postgresql_master_setup_sql",
     ]
   }
@@ -305,7 +305,7 @@ resource "null_resource" "postgresql_master_setup" {
     }
 
     content     = element(data.template_file.postgresql_master_setup_sh.*.rendered, 0)
-    destination = "~/postgresql_master_setup.sh"
+    destination = "/tmp/postgresql_master_setup.sh"
   }
 
   provisioner "file" {
@@ -330,8 +330,8 @@ resource "null_resource" "postgresql_master_setup" {
 
     }
     inline = [
-      "chmod +x ~/postgresql_master_setup.sh",
-      "sudo ~/postgresql_master_setup.sh"
+      "chmod +x /tmp/postgresql_master_setup.sh",
+      "sudo /tmp/postgresql_master_setup.sh"
     ]
   }
 }
@@ -349,7 +349,7 @@ resource "null_resource" "postgresql_master_setup2" {
 
     }
     inline = [
-      "sudo rm -rf ~/postgresql_master_setup2.sh",
+      "sudo rm -rf /tmp/postgresql_master_setup2.sh",
     ]
   }
 
@@ -363,7 +363,7 @@ resource "null_resource" "postgresql_master_setup2" {
     }
 
     content     = element(data.template_file.postgresql_master_setup2_sh.*.rendered, 0)
-    destination = "~/postgresql_master_setup2.sh"
+    destination = "/tmp/postgresql_master_setup2.sh"
   }
 
   provisioner "remote-exec" {
@@ -375,8 +375,8 @@ resource "null_resource" "postgresql_master_setup2" {
 
     }
     inline = [
-      "chmod +x ~/postgresql_master_setup2.sh",
-      "sudo ~/postgresql_master_setup2.sh"
+      "chmod +x /tmp/postgresql_master_setup2.sh",
+      "sudo /tmp/postgresql_master_setup2.sh"
     ]
   }
 }
@@ -395,7 +395,7 @@ resource "null_resource" "postgresql_hotstandby1_setup" {
 
     }
     inline = [
-      "sudo rm -rf ~/postgresql_standby_setup.sh",
+      "sudo rm -rf /tmp/postgresql_standby_setup.sh",
     ]
   }
 
@@ -409,7 +409,7 @@ resource "null_resource" "postgresql_hotstandby1_setup" {
     }
 
     content     = element(data.template_file.postgresql_standby_setup_sh.*.rendered, 0)
-    destination = "~/postgresql_standby_setup.sh"
+    destination = "/tmp/postgresql_standby_setup.sh"
   }
 
   provisioner "remote-exec" {
@@ -421,8 +421,8 @@ resource "null_resource" "postgresql_hotstandby1_setup" {
 
     }
     inline = [
-      "chmod +x ~/postgresql_standby_setup.sh",
-      "sudo ~/postgresql_standby_setup.sh"
+      "chmod +x /tmp/postgresql_standby_setup.sh",
+      "sudo /tmp/postgresql_standby_setup.sh"
     ]
   }
 }
@@ -440,7 +440,7 @@ resource "null_resource" "postgresql_hotstandby2_setup" {
 
     }
     inline = [
-      "sudo rm -rf ~/postgresql_standby_setup.sh",
+      "sudo rm -rf /tmp/postgresql_standby_setup.sh",
     ]
   }
 
@@ -454,7 +454,7 @@ resource "null_resource" "postgresql_hotstandby2_setup" {
     }
 
     content     = element(data.template_file.postgresql_standby_setup_sh.*.rendered, 0)
-    destination = "~/postgresql_standby_setup.sh"
+    destination = "/tmp/postgresql_standby_setup.sh"
   }
 
   provisioner "remote-exec" {
@@ -466,8 +466,8 @@ resource "null_resource" "postgresql_hotstandby2_setup" {
 
     }
     inline = [
-      "chmod +x ~/postgresql_standby_setup.sh",
-      "sudo ~/postgresql_standby_setup.sh"
+      "chmod +x /tmp/postgresql_standby_setup.sh",
+      "sudo /tmp/postgresql_standby_setup.sh"
     ]
   }
 }

--- a/scripts/postgresql_master_initdb.sh
+++ b/scripts/postgresql_master_initdb.sh
@@ -19,25 +19,12 @@ Environment=PGLOG=/u01/data/pgstartup.log
 EOF
 
 # Optionally initialize the database and enable automatic start:
-if [[ $pg_version == "9.6" ]]; then 
-	sudo su - postgres -c  "/usr/pgsql-${pg_version}/bin/initdb -D $DATA_DIR"
-	sudo semanage fcontext -a -t postgresql_db_t "/u01/data(/.*)?"
-	sudo restorecon -R -v /u01/data
-else
-	sudo su - postgres -c  "/usr/pgsql-${pg_version}/bin/initdb -D $DATA_DIR"
-	sudo semanage fcontext -a -t postgresql_db_t "/u01/data(/.*)?"
-	sudo restorecon -R -v /u01/data
-fi	
+sudo su - postgres -c  "/usr/pgsql-${pg_version}/bin/initdb -D $DATA_DIR"
+sudo semanage fcontext -a -t postgresql_db_t "/u01/data(/.*)?"
+sudo restorecon -R -v /u01/data
 
-#sudo systemctl enable postgresql-${pg_version}
-#sudo systemctl start postgresql-${pg_version}
-#sudo systemctl status postgresql-${pg_version}
 sudo systemctl enable postgresql
 sudo systemctl start postgresql
 sudo systemctl status postgresql
 
-if [[ $pg_version == "9.6" ]]; then 
-	sudo -u root bash -c "tail -5 /u01/data/pg_log/postgresql-*.log"
-else
-	sudo -u root bash -c "tail -5 /u01/data/log/postgresql-*.log"
-fi
+sudo -u root bash -c "tail -5 /u01/data/log/postgresql-*.log"


### PR DESCRIPTION
Terraform seems to not longer allow for `~/` in the paths for provisioning files.

Creating all scripts in the `/tmp` directory handles this nicely.

I have also updated and tested the latest versions of Postgres and updated the README accordingly.