### PR TITLE
Adds auto restart to PostgreSQL service

### DIFF
--- a/scripts/postgresql_master_initdb.sh
+++ b/scripts/postgresql_master_initdb.sh
@@ -12,10 +12,11 @@ sudo chown -R postgres:postgres /u01
 sudo tee -a /etc/systemd/system/postgresql.service > /dev/null <<'EOF'
 .include /usr/lib/systemd/system/postgresql-${pg_version}.service
 [Service]
-
 # Location of database directory
 Environment=PGDATA=/u01/data
 Environment=PGLOG=/u01/data/pgstartup.log
+Restart=always
+RestartSec=3
 EOF
 
 # Optionally initialize the database and enable automatic start:

--- a/scripts/postgresql_standby_setup.sh
+++ b/scripts/postgresql_standby_setup.sh
@@ -12,10 +12,11 @@ sudo chown -R postgres:postgres /u01
 sudo tee /etc/systemd/system/postgresql.service > /dev/null <<'EOF'
 .include /usr/lib/systemd/system/postgresql-${pg_version}.service
 [Service]
-
 # Location of database directory
 Environment=PGDATA=/u01/data
 Environment=PGLOG=/u01/data/pgstartup.log
+Restart=always
+RestartSec=3
 EOF
 
 # Change password of postgres user


### PR DESCRIPTION
Simple addition that means if the service is to crash or fail to recover on boot (this one happened to me), it will restart itself and recover.